### PR TITLE
[Python 2 removal] Shebang env, remove futures

### DIFF
--- a/symbolicate-crash
+++ b/symbolicate-crash
@@ -1,5 +1,4 @@
-#!/usr/bin/python
-from __future__ import print_function
+#!/usr/bin/env python
 
 def replace_dashes(text):
     return text.replace('-', '')


### PR DESCRIPTION
macOS Monterey has officially removed python 2 as a built-in (plus being EOL). `/usr/bin` no longer contains a `python` executable - only `python3`.

We'll update the shebang line here to lookup python in the current environment - also removing the `futures` import since `print()` is widely available.